### PR TITLE
Lodash? We don't need no stinkin' Lodash!

### DIFF
--- a/posts/ramdaScrape.md
+++ b/posts/ramdaScrape.md
@@ -187,7 +187,7 @@ request('https://en.wikipedia.org/wiki/George_Washington')
     bday: $('.bday').text(),
   }
 })
-.then(console.log) //=> { names: ['George', 'Washington'], dob: '1732-02-22' }
+.then(console.log) //=> { names: [ 'George', 'Washington' ], bday: '1732-02-22' }
 ```
 
 Let's add some more properties.  Some of these parsing queries get pretty ugly, but that is just the nature of scraping web pages.

--- a/posts/ramdaScrape.md
+++ b/posts/ramdaScrape.md
@@ -178,7 +178,7 @@ Run that and you'll get:
 Great!  Using the same process of inspecting elements we find there is a `bday` class on the George Washinton page.
 
 ```javascript
-request('httsp://en.wikipedia.org/wiki/George_Washington')
+request('https://en.wikipedia.org/wiki/George_Washington')
 .then(R.prop('body'))
 .then(cheerio.load)
 .then(function($){


### PR DESCRIPTION
Hello there. I went through this excellent 👍  tutorial and fixed all things that were breaking along the way, such as no responses due to missing User Agent header, HTTPS or updated Wikipedia pages, deprecated Ramda methods, etc. 

Along the way, I decided to drop lodash, since Ramda does a pretty good job on the _.compact, _.curry and _.partialRight methods. It looks much cleaner and focuses on Ramda this way.

Take a look, and double check the results from the code, and let me know what you think.

Once again, congratulations on one of the best walk throughs of Ramda.

P.S. I had a really hard time walking through the article's code, due to the lack of proper syntax highlighting. It would be great if you could also fix the problem with the prism library.